### PR TITLE
Fix chinese search

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ It literally copies all of the CSS from https://nitter.net so you should be able
 use any of Nitter's [themes](https://github.com/zedeus/nitter/tree/master/public/css/themes). Just
 copy the CSS file and replace `twitter.css` in the `index.html` with the theme
 of your choice.
+
+### Features
+
+- Chinese tweet search optimization.

--- a/app.js
+++ b/app.js
@@ -21,6 +21,29 @@ const app = Vue.createApp({
             fields: ['full_text'], // fields to index for full-text search
             storeFields: ['full_text', 'created_at', 'id_str', 'favorite_count', 'retweet_count'],
             idField: 'id_str',
+            tokenize: (term) => {
+                if (typeof term === 'string') term = term.toLowerCase();
+                const segmenter = Intl.Segmenter && new Intl.Segmenter("zh", { granularity: "word" });
+                if (!segmenter) return [term];
+                const tokens = [];
+                for (const seg of segmenter.segment(term)) {
+                    tokens.push(seg.segment);
+                }
+                return tokens;
+            },
+            searchOptions: {
+                combineWith: 'AND', // important for search chinese
+                processTerm: (term) => {
+                    if (typeof term === 'string') term = term.toLowerCase();
+                    const segmenter = Intl.Segmenter && new Intl.Segmenter("zh", { granularity: "word" });
+                    if (!segmenter) return term;
+                    const tokens = [];
+                    for (const seg of segmenter.segment(term)) {
+                        tokens.push(seg.segment);
+                    }
+                    return tokens;
+                },
+            },
         });
         this.miniSearch.addAll(this.tweets);
         /* infinite scroll */


### PR DESCRIPTION
Default `minisearch` settings do not work for Chinese tweets
cases:
- "我喝咖啡" would not be found when searching for "咖啡"
- "我是leverglowh" would not be found when searching for "leverglowh"

To fix this, the minisearch initialization is edited according to https://github.com/lucaong/minisearch/issues/201#issuecomment-2227591121.

This should fix both aforementioned cases.